### PR TITLE
feat: add support for private link endpoints

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ name: verify-pre-commit
 #   - Terraform validate with tflint
 #   - check for merge conflicts
 #   - fix end of files
-# 
+#
 # The preCommitMinVersions job will check that terraform validates with the minimum
 # allowed version of the module.
 # The preCommitMaxVersion job will check that terraform validates with the maximum

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.tf"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: tx-pts-dai/github-workflows/.github/workflows/gh-release-on-main.yaml@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,14 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.90.0
     hooks:
       - id: terraform_fmt
+        args:
+          - '--args=-recursive'
       - id: terraform_validate
+        args:
+          - --tf-init-args=-upgrade
+          - --tf-init-args=-lockfile=false
       - id: terraform_docs
         args:
           - '--args=--lockfile=false'
@@ -23,7 +28,13 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: no-commit-to-branch
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 37.399.9
+    hooks:
+      - id: renovate-config-validator

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ as described in the `.pre-commit-config.yaml` file
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.0.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_mongodbatlas"></a> [mongodbatlas](#requirement\_mongodbatlas) | >= 1.0 |
 
@@ -113,9 +113,13 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_route.atlas_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_vpc_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_peering_connection_accepter.atlas](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) | resource |
 | [mongodbatlas_network_container.container](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/network_container) | resource |
 | [mongodbatlas_network_peering.peering](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/network_peering) | resource |
+| [mongodbatlas_privatelink_endpoint.this](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint) | resource |
+| [mongodbatlas_privatelink_endpoint_service.this](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_service) | resource |
 | [mongodbatlas_project.project](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/project) | resource |
 | [mongodbatlas_project_ip_access_list.additional_cidr](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/project_ip_access_list) | resource |
 | [mongodbatlas_project_ip_access_list.public_ips](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/project_ip_access_list) | resource |
@@ -130,12 +134,14 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_atlas_cidr_block"></a> [atlas\_cidr\_block](#input\_atlas\_cidr\_block) | CIDR block for MongoDB resources | `string` | `"10.8.0.0/21"` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | Region for AWS and for Mongodb resources | `string` | n/a | yes |
+| <a name="input_create_privatelink"></a> [create\_privatelink](#input\_create\_privatelink) | Create a PrivateLink Connection if set to True for instances that are M10 size or higher | `bool` | `false` | no |
+| <a name="input_create_project"></a> [create\_project](#input\_create\_project) | Create a project on Atlas if set to True | `bool` | `true` | no |
 | <a name="input_create_vpc_peering"></a> [create\_vpc\_peering](#input\_create\_vpc\_peering) | Create a Vpc Peering Connection if set to True for instances that are M10 size or higher | `bool` | n/a | yes |
 | <a name="input_mongodb_atlas_org_id"></a> [mongodb\_atlas\_org\_id](#input\_mongodb\_atlas\_org\_id) | ID of the Organization on Atlas | `string` | n/a | yes |
 | <a name="input_override_peering_cidr"></a> [override\_peering\_cidr](#input\_override\_peering\_cidr) | Manually overrides the network peering cidr block | `string` | `null` | no |
-| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | AWS private networks subnets which can connect to the db and which enable HA | `list(any)` | n/a | yes |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | AWS private subnet ids which can connect to the db and which enable HA | `list(string)` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name of the Mongodb project | `string` | n/a | yes |
-| <a name="input_provider_name"></a> [provider\_name](#input\_provider\_name) | Provider name for Atlas Mongodb resources | `string` | n/a | yes |
+| <a name="input_provider_name"></a> [provider\_name](#input\_provider\_name) | Provider name for Atlas Mongodb resources | `string` | `"AWS"` | no |
 | <a name="input_team_ids"></a> [team\_ids](#input\_team\_ids) | Id of the infra team of the Organization on Atlas | <pre>list(object({<br>    team_id   = string<br>    team_role = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC of Atlas MongoDB resources | `string` | n/a | yes |
 | <a name="input_vpc_public_ips"></a> [vpc\_public\_ips](#input\_vpc\_public\_ips) | List of public IP addresses of the VPC | `list(string)` | n/a | yes |
@@ -145,6 +151,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_peering_id"></a> [peering\_id](#output\_peering\_id) | Network peering |
+| <a name="output_private_link_endpoint"></a> [private\_link\_endpoint](#output\_private\_link\_endpoint) | Private link |
 | <a name="output_project_id"></a> [project\_id](#output\_project\_id) | Mongodb project id |
 | <a name="output_region_name"></a> [region\_name](#output\_region\_name) | Mongodb region name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_route_table.private_routing_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [mongodbatlas_project.this](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 
@@ -144,7 +145,7 @@ No modules.
 | <a name="input_provider_name"></a> [provider\_name](#input\_provider\_name) | Provider name for Atlas Mongodb resources | `string` | `"AWS"` | no |
 | <a name="input_team_ids"></a> [team\_ids](#input\_team\_ids) | Id of the infra team of the Organization on Atlas | <pre>list(object({<br>    team_id   = string<br>    team_role = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC of Atlas MongoDB resources | `string` | n/a | yes |
-| <a name="input_vpc_public_ips"></a> [vpc\_public\_ips](#input\_vpc\_public\_ips) | List of public IP addresses of the VPC | `list(string)` | n/a | yes |
+| <a name="input_vpc_public_ips"></a> [vpc\_public\_ips](#input\_vpc\_public\_ips) | List of public IP addresses of the VPC | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,3 @@
-terraform {
-  required_version = ">=1.0.4"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.0"
-    }
-    mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = ">= 1.0"
-    }
-  }
-}
-
 data "aws_caller_identity" "current" {}
 
 data "aws_vpc" "this" {
@@ -19,8 +5,11 @@ data "aws_vpc" "this" {
 }
 
 resource "mongodbatlas_project" "project" {
+  count = var.create_project ? 1 : 0
+
   org_id = var.mongodb_atlas_org_id
   name   = var.project_name
+
   dynamic "teams" {
     for_each = var.team_ids
     content {
@@ -31,33 +20,38 @@ resource "mongodbatlas_project" "project" {
 }
 
 resource "mongodbatlas_project_ip_access_list" "vpc" {
-  count      = var.create_vpc_peering == true ? 1 : 0
-  project_id = mongodbatlas_project.project.id
+  count = var.create_vpc_peering ? 1 : 0
+
+  project_id = mongodbatlas_project.project[0].id
   cidr_block = data.aws_vpc.this.cidr_block
 }
 
 resource "mongodbatlas_project_ip_access_list" "additional_cidr" {
-  count      = var.override_peering_cidr != null ? 1 : 0
-  project_id = mongodbatlas_project.project.id
+  count = var.override_peering_cidr != null ? 1 : 0
+
+  project_id = mongodbatlas_project.project[0].id
   cidr_block = var.override_peering_cidr
 }
 
 resource "mongodbatlas_project_ip_access_list" "public_ips" {
-  for_each   = toset(var.create_vpc_peering == true ? [] : var.vpc_public_ips)
-  project_id = mongodbatlas_project.project.id
+  for_each = toset(var.create_vpc_peering ? [] : var.vpc_public_ips)
+
+  project_id = mongodbatlas_project.project[0].id
   ip_address = each.value
 }
 
 resource "mongodbatlas_network_container" "container" {
-  count            = var.create_vpc_peering == true ? 1 : 0
-  project_id       = mongodbatlas_project.project.id
+  count = var.create_vpc_peering ? 1 : 0
+
+  project_id       = mongodbatlas_project.project[0].id
   atlas_cidr_block = var.atlas_cidr_block
   provider_name    = var.provider_name
   region_name      = upper(replace(var.aws_region, "-", "_"))
 }
 
 resource "mongodbatlas_network_peering" "peering" {
-  count                  = var.create_vpc_peering == true ? 1 : 0
+  count = var.create_vpc_peering ? 1 : 0
+
   accepter_region_name   = var.aws_region
   project_id             = mongodbatlas_network_container.container[0].project_id
   container_id           = mongodbatlas_network_container.container[0].container_id
@@ -68,19 +62,73 @@ resource "mongodbatlas_network_peering" "peering" {
 }
 
 resource "aws_vpc_peering_connection_accepter" "atlas" {
-  count                     = var.create_vpc_peering == true ? 1 : 0
+  count = var.create_vpc_peering ? 1 : 0
+
   vpc_peering_connection_id = mongodbatlas_network_peering.peering[0].connection_id
   auto_accept               = true
 }
 
 data "aws_route_table" "private_routing_tables" {
-  for_each  = toset(var.private_subnets)
+  for_each = toset(var.private_subnets)
+
   subnet_id = each.value
 }
 
 resource "aws_route" "atlas_route" {
-  for_each                  = toset([for o in data.aws_route_table.private_routing_tables : o.route_table_id if var.create_vpc_peering == true])
+  for_each = toset([for o in data.aws_route_table.private_routing_tables : o.route_table_id if var.create_vpc_peering == true])
+
   route_table_id            = each.value
   destination_cidr_block    = var.atlas_cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection_accepter.atlas[0].id
+}
+
+resource "aws_vpc_endpoint" "this" {
+  count = var.create_privatelink ? 1 : 0
+
+  vpc_id             = data.aws_vpc.this.id
+  service_name       = mongodbatlas_privatelink_endpoint.this[0].endpoint_service_name
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = var.private_subnets
+  security_group_ids = [aws_security_group.this[0].id]
+}
+
+resource "mongodbatlas_privatelink_endpoint" "this" {
+  count = var.create_privatelink ? 1 : 0
+
+  project_id    = mongodbatlas_project.project[0].id
+  provider_name = "AWS"
+  region        = var.aws_region
+}
+
+resource "mongodbatlas_privatelink_endpoint_service" "this" {
+  count = var.create_privatelink ? 1 : 0
+
+  project_id          = mongodbatlas_privatelink_endpoint.this[0].project_id
+  private_link_id     = mongodbatlas_privatelink_endpoint.this[0].id
+  endpoint_service_id = aws_vpc_endpoint.this[0].id
+  provider_name       = "AWS"
+}
+
+resource "aws_security_group" "this" {
+  count = var.create_privatelink ? 1 : 0
+
+  name_prefix = "mongodbatlas-privatelink"
+  description = "Security group for MongoDB Atlas Private Link"
+  vpc_id      = data.aws_vpc.this.id
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "tcp"
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = mongodbatlas_project.project
+  to   = mongodbatlas_project.project[0]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,11 +4,16 @@ output "peering_id" {
 }
 
 output "project_id" {
-  value       = mongodbatlas_project.project.id
+  value       = mongodbatlas_project.project[0].id
   description = "Mongodb project id"
 }
 
 output "region_name" {
   value       = upper(replace(var.aws_region, "-", "_"))
   description = "Mongodb region name"
+}
+
+output "private_link_endpoint" {
+  value       = var.create_privatelink == true ? aws_vpc_endpoint.this[0] : null
+  description = "Private link"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "peering_id" {
 }
 
 output "project_id" {
-  value       = mongodbatlas_project.project[0].id
+  value       = local.project_id
   description = "Mongodb project id"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,27 +1,30 @@
 variable "provider_name" {
-  type        = string
   description = "Provider name for Atlas Mongodb resources"
+  type        = string
+
+  default = "AWS"
 }
 
 variable "atlas_cidr_block" {
-  default     = "10.8.0.0/21"
-  description = " CIDR block for MongoDB resources "
+  description = "CIDR block for MongoDB resources"
   type        = string
+
+  default = "10.8.0.0/21"
 }
 
 variable "aws_region" {
+  description = "Region for AWS and for Mongodb resources"
   type        = string
-  description = "Region for AWS and for Mongodb resources "
 }
 
 variable "vpc_id" {
+  description = "VPC of Atlas MongoDB resources"
   type        = string
-  description = "VPC of Atlas MongoDB resources "
 }
 
 variable "vpc_public_ips" {
-  type        = list(string)
   description = "List of public IP addresses of the VPC"
+  type        = list(string)
 }
 
 variable "mongodb_atlas_org_id" {
@@ -29,23 +32,31 @@ variable "mongodb_atlas_org_id" {
   description = "ID of the Organization on Atlas"
 }
 
+variable "create_project" {
+  description = "Create a project on Atlas if set to True"
+  type        = bool
+
+  default = true
+}
+
 variable "project_name" {
-  type        = string
   description = "Name of the Mongodb project"
+  type        = string
 }
 
 variable "team_ids" {
+  description = "Id of the infra team of the Organization on Atlas"
   type = list(object({
     team_id   = string
     team_role = list(string)
   }))
-  default     = []
-  description = "Id of the infra team of the Organization on Atlas"
+
+  default = []
 }
 
 variable "private_subnets" {
-  type        = list(any)
-  description = "AWS private networks subnets which can connect to the db and which enable HA "
+  description = "AWS private subnet ids which can connect to the db and which enable HA"
+  type        = list(string)
 }
 
 variable "create_vpc_peering" {
@@ -54,7 +65,15 @@ variable "create_vpc_peering" {
 }
 
 variable "override_peering_cidr" {
-  type        = string
-  default     = null
   description = "Manually overrides the network peering cidr block"
+  type        = string
+
+  default = null
+}
+
+variable "create_privatelink" {
+  description = "Create a PrivateLink Connection if set to True for instances that are M10 size or higher"
+  type        = bool
+
+  default = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,35 @@
+variable "mongodb_atlas_org_id" {
+  type        = string
+  description = "ID of the Organization on Atlas"
+}
+
 variable "provider_name" {
   description = "Provider name for Atlas Mongodb resources"
   type        = string
 
   default = "AWS"
+}
+
+variable "create_project" {
+  description = "Create a project on Atlas if set to True"
+  type        = bool
+
+  default = true
+}
+
+variable "project_name" {
+  description = "Name of the Mongodb project"
+  type        = string
+}
+
+variable "team_ids" {
+  description = "Id of the infra team of the Organization on Atlas"
+  type = list(object({
+    team_id   = string
+    team_role = list(string)
+  }))
+
+  default = []
 }
 
 variable "atlas_cidr_block" {
@@ -25,31 +52,6 @@ variable "vpc_id" {
 variable "vpc_public_ips" {
   description = "List of public IP addresses of the VPC"
   type        = list(string)
-}
-
-variable "mongodb_atlas_org_id" {
-  type        = string
-  description = "ID of the Organization on Atlas"
-}
-
-variable "create_project" {
-  description = "Create a project on Atlas if set to True"
-  type        = bool
-
-  default = true
-}
-
-variable "project_name" {
-  description = "Name of the Mongodb project"
-  type        = string
-}
-
-variable "team_ids" {
-  description = "Id of the infra team of the Organization on Atlas"
-  type = list(object({
-    team_id   = string
-    team_role = list(string)
-  }))
 
   default = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">=1.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+      version = ">= 1.0"
+    }
+  }
+}


### PR DESCRIPTION
added minimal support for private link endpoint


ran some linting and sanitising on the repo

Example of only create private link in an already existing project

```
data "aws_subnets" "private" {
  filter {
    name   = "tag:Name"
    values = ["*-private-*"]
  }
}

## Resources
module "mongodb" {
  source = "github.com/tx-pts-dai/terraform-aws-mongodbatlas.git?ref=fum-3325-private-link"

  mongodb_atlas_org_id = "xxxxxx"

  create_project       = false
  project_name         = "Some Project"

  aws_region           = var.region

  vpc_id               = module.network.vpc.vpc_id
  private_subnets      = data.aws_subnets.private.ids

  create_vpc_peering   = false
  create_privatelink   = true
}
```