### PR TITLE
fix: allowing all protocols for inbound traffic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ resource "aws_security_group" "this" {
   ingress {
     from_port = 0
     to_port   = 0
-    protocol  = "tcp"
+    protocol  = "-1"
     cidr_blocks = [
       "0.0.0.0/0",
     ]


### PR DESCRIPTION
**Context:** 
While connecting to the MongoDB cluster via a private endpoint, the connection cannot be established due to a restriction in the inbound security group policy.